### PR TITLE
Keeps canary from overriding custom 404 messages

### DIFF
--- a/src/ErrorHandler.php
+++ b/src/ErrorHandler.php
@@ -11,6 +11,7 @@ class ErrorHandler extends \craft\web\ErrorHandler
 	 */
 	protected function renderException($exception): void
 	{
+		$this->errorAction = 'templates/render-error';
 		$this->exceptionView = __DIR__.'/view/views/errorPage.php';
 		parent::renderException($exception);
 	}


### PR DESCRIPTION
If we install this plugin it obliterates our custom 404 messages on our production site for non-logged in users.